### PR TITLE
Prevent output of headers by the property_details shortcode

### DIFF
--- a/includes/class-listings.php
+++ b/includes/class-listings.php
@@ -213,11 +213,17 @@ class AgentPress_Listings {
 
 		$output .= '<div class="property-details-col1 one-half first">';
 		foreach ( (array) $this->property_details['col1'] as $label => $key ) {
-			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );
+			$value = get_post_meta($post->ID, $key, true);
+			if ( !empty( $value ) ) {
+				$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( $value ) );
+			}
 		}
 		$output .= '</div><div class="property-details-col2 one-half">';
 		foreach ( (array) $this->property_details['col2'] as $label => $key ) {
-			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );
+			$value = get_post_meta($post->ID, $key, true);
+			if ( !empty( $value ) ) {
+				$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( $value ) );
+			}
 		}
 		$output .= '</div>'; // end .one-half
 

--- a/includes/class-listings.php
+++ b/includes/class-listings.php
@@ -212,17 +212,23 @@ class AgentPress_Listings {
 		$output .= '<div class="property-details">';
 
 		$output .= '<div class="property-details-col1 one-half first">';
-			foreach ( (array) $this->property_details['col1'] as $label => $key ) {
-				$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );	
-			}
+		foreach ( (array) $this->property_details['col1'] as $label => $key ) {
+			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );
+		}
 		$output .= '</div><div class="property-details-col2 one-half">';
-			foreach ( (array) $this->property_details['col2'] as $label => $key ) {
-				$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );	
-			}
-		$output .= '</div><div class="clear">';
-			$output .= sprintf( '<p><b>%s</b><br /> %s</p></div>', __( 'Additional Features:', 'agentpress-listings' ), get_the_term_list( $post->ID, 'features', '', ', ', '' ) );
+		foreach ( (array) $this->property_details['col2'] as $label => $key ) {
+			$output .= sprintf( '<b>%s</b> %s<br />', esc_html( $label ), esc_html( get_post_meta($post->ID, $key, true) ) );
+		}
+		$output .= '</div>'; // end .one-half
 
-		$output .= '</div>';
+		// Output Additional features if any are attached to the Listing
+		$features = get_the_terms( $post->ID, 'features');
+		if ( !empty( $features ) ) {
+			$output .= '<div class="clear">';
+			$output .= sprintf('<p><b>%s</b><br /> %s</p></div>', __('Additional Features:', 'agentpress-listings'), get_the_term_list($post->ID, 'features', '', ', ', ''));
+		}
+
+		$output .= '</div>'; // end .property-details
 
 		return $output;
 

--- a/includes/class-taxonomies.php
+++ b/includes/class-taxonomies.php
@@ -194,6 +194,8 @@ class AgentPress_Taxonomies {
 			'choose_from_most_used' => sprintf( __( 'Choose from the most used %s', 'agentpress-listings' ), strip_tags( $args['name'] ) )
 		);
 
+		$id = $args['id'];
+		
 		$args = array(
 			'labels'       => $labels,
 			'hierarchical' => true,


### PR DESCRIPTION
The [property_details] shortcode adds an “Additional Features” heading at the end of the property details even if no features are attached to the listing in the Features meta box.

It also outputs headings in the property details section even if details aren't added (issue #6 ). This PR includes a fix for both.

I recommend also updating AgentPress Pro to include this CSS to hide the first column if there are no entries in it and avoid display issues like this: http://d.pr/i/1jk2E

    .property-details-col1:empty,
    .property-details-col2:empty {
        display: none;
    }

`:empty` doesn't work in IE8 or below, but it should improves things for modern browsers.